### PR TITLE
Ignore Hugo build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 public/
-resources/
+resources/_gen/
 hugo_stats.json
 .hugo_build.lock


### PR DESCRIPTION
## Summary
- ignore Hugo build outputs: `public/`, `resources/_gen/`, `hugo_stats.json`
- clean repo of any previously tracked generated artifacts

## Testing
- `hugo --minify` *(fails: module "github.com/HugoBlox/hugo-blox-builder/modules/blox-tailwind" is not compatible with this Hugo version)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9822e8ac83208a73caa5f3963744