### PR TITLE
Fix nav anchor and configure markdownlint

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+MD013: false
+MD033: false
+MD046: false
+MD036: false
+MD012: false
+MD009: false

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-MIT License
+# MIT License
 
-Copyright (c) 2023-present George Cushen (https://georgecushen.com/)
+Copyright (c) 2023-present George Cushen ([georgecushen.com](https://georgecushen.com/))
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/config/_default/menus.en.yaml
+++ b/config/_default/menus.en.yaml
@@ -8,7 +8,7 @@ main:
     url: ""
     weight: 10
   - name: Publications
-    url: "#papers"
+    url: "/#papers"
     weight: 11
   # - name: News
   #   url: "#news"


### PR DESCRIPTION
## Summary
- fix Publications menu link to point to home page anchor
- add markdownlint config and resolve license linter issues

## Testing
- `hugo --gc` (fails: error building site: render: failed to render pages)
- `htmltest public` (fails: network is unreachable; 1332 errors in 167 documents)
- `markdownlint '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bc9a2a6d7c8320abcf7d35590b0ca9